### PR TITLE
Batch process files too large for the lambda function

### DIFF
--- a/clamav.py
+++ b/clamav.py
@@ -133,4 +133,5 @@ def scan_file(path):
     else:
         msg = "Unexpected exit code from clamscan: %s.\n" % av_proc.returncode
         print(msg)
+        print("Make sure the CLAM variables in common.py are set correctly for this system")
         raise Exception(msg)

--- a/scan.py
+++ b/scan.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 # Upside Travel, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# Modifications for Dryad made by Daisie Huang
 
 import boto3
 import botocore

--- a/scan.py
+++ b/scan.py
@@ -226,19 +226,21 @@ def main():
         s3_object = s3.Object(bucket_name, key)
         print("Scanning " + object)
         sns_start_scan(s3_object)
-        file_path = download_s3_object(s3_object, LARGE_FILE_TEMP_PATH)
-        scan_result = clamav.scan_file(file_path)
-        print("Scan of s3://%s resulted in %s\n" % (os.path.join(s3_object.bucket_name, s3_object.key), scan_result))
-        if "AV_UPDATE_METADATA" in os.environ:
-            set_av_metadata(s3_object, scan_result)
-        set_av_tags(s3_object, scan_result)
-        sns_scan_results(s3_object, scan_result)
-        metrics.send(env=ENV, bucket=s3_object.bucket_name, key=s3_object.key, status=scan_result)
         try:
-            os.remove(file_path)
-        except OSError:
+            file_path = download_s3_object(s3_object, LARGE_FILE_TEMP_PATH)
+            scan_result = clamav.scan_file(file_path)
+            print("Scan of s3://%s resulted in %s\n" % (os.path.join(s3_object.bucket_name, s3_object.key), scan_result))
+            if "AV_UPDATE_METADATA" in os.environ:
+                set_av_metadata(s3_object, scan_result)
+            set_av_tags(s3_object, scan_result)
+            sns_scan_results(s3_object, scan_result)
+            metrics.send(env=ENV, bucket=s3_object.bucket_name, key=s3_object.key, status=scan_result)
+            try:
+                os.remove(file_path)
+            except OSError:
+                pass
+        except botocore.exceptions.ClientError:
             pass
-
 
 if __name__ == '__main__':
     main()

--- a/scan.py
+++ b/scan.py
@@ -57,7 +57,7 @@ def is_object_scannable(s3_object):
         lf.write(s3_object.bucket_name + "/" + s3_object.key + "\n")
         lf.close()
         LOG.upload_file(LOGFILE)
-        raise SizeError("File too big for lambda")
+        raise SizeError("Too big for lambda: %s" % (s3_object.key))
     if (summary.storage_class == 'GLACIER'):
         lf.write(s3_object.bucket_name + "/" + s3_object.key + "\n")
         lf.close()

--- a/scan.py
+++ b/scan.py
@@ -205,7 +205,6 @@ def main():
         LOG.download_file(LOGFILE)
         LOG.delete()
     except botocore.exceptions.ClientError as e:
-        print("Couldn't find the log file: it is probably being written right now")
         sys.exit()
     
     lf = open(LOGFILE,"r")


### PR DESCRIPTION
Files that are too large to be scanned by a lambda function are written out to a separate file, stored at s3://dryad-logs/unscanned_files.txt. If there are files listed there, scan.py will scan them one at a time. This can be easily invoked via crontab.